### PR TITLE
Fix order of tasks in RedHat, skip them if already installed

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,5 +1,6 @@
 ---
 postgres_rpm_repo_url: 'https://download.postgresql.org/pub/repos/yum/reporpms/EL-{{ ansible_distribution_major_version }}-x86_64/pgdg-redhat-repo-latest.noarch.rpm'
 postgres_repo_gpg_key_url: 'https://download.postgresql.org/pub/repos/yum/RPM-GPG-KEY-PGDG'
+postgres_repofile_path: '/etc/yum.repos.d/pgdg-redhat-all.repo'
 postgresql_apt_key: 'https://www.postgresql.org/media/keys/ACCC4CF8.asc'
 postgresql_apt_repo_url: 'deb http://apt.postgresql.org/pub/repos/apt/ {{ ansible_distribution_release }}-pgdg main'

--- a/tasks/setup-RedHat.yml
+++ b/tasks/setup-RedHat.yml
@@ -1,11 +1,18 @@
 ---
-- name: install postgres repo
-  yum:
-    name: '{{ postgres_rpm_repo_url }}'
-    state: present
+- name: Check if postgres repo is already configured.
+  stat:
+    path: "{{ postgres_repofile_path }}"
+  register: postgres_repofile_result
 
 - name: import gpg key
   rpm_key:
     key: '{{ item }}'
     state: present
   with_items: '{{ postgres_repo_gpg_key_url }}'
+  when: not postgres_repofile_result.stat.exists
+
+- name: install postgres repo
+  yum:
+    name: '{{ postgres_rpm_repo_url }}'
+    state: present
+  when: not postgres_repofile_result.stat.exists


### PR DESCRIPTION
On my CentOS 8 system, it was necessary to install the GPG key first. Otherwise, I would get an error that the repo could not be validated.

I also added a check to see repo is already installed, so that the remaining tasks can be skipped on subsequent runs.

Thank you for making this role!